### PR TITLE
chore: delete deprecated `application` repository

### DIFF
--- a/modules/repositories/locals.tf
+++ b/modules/repositories/locals.tf
@@ -76,11 +76,6 @@ locals {
         }
       }
     },
-    application = {
-      description = "Main application repository for the TerraHarbor project"
-      topics      = ["terraharbor", "terraform-backend"]
-      visibility  = "public"
-    },
     frontend = {
       description = "Frontend of the TerraHarbor application written in React"
       topics      = ["terraharbor", "terraform-backend", "react", "docker"]

--- a/modules/repositories/main.tf
+++ b/modules/repositories/main.tf
@@ -55,6 +55,12 @@ resource "github_repository" "repository" {
   # squash_merge_commit_title   = "PR_TITLE"
 
   auto_init = true
+
+  lifecycle {
+    ignore_changes = [
+      pages
+    ]
+  }
 }
 
 resource "time_sleep" "wait_for_repo_creation" {


### PR DESCRIPTION
This PR is just to delete the old `application` repository, that has been superseded by the `frontend` and `backend` repositories. Closes #15.